### PR TITLE
Restore webhook after email field removal

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,7 +180,7 @@
             <button id="print-dashboard-btn" class="boton-panel-pdf"><i class="fas fa-share-alt"></i> Compartir / Guardar Panel (PDF)</button>
         </div>
 
-        <div id="assignment-dashboard-section">
+        <div id="assignment-dashboard-section" class="hidden-section">
             <div class="folder-tab">📂 <span><strong>Panel Detectivesco</strong></span></div>
             <div class="table-responsive-wrapper">
                 <div id="assignment-table-container">

--- a/script.js
+++ b/script.js
@@ -123,7 +123,7 @@ function initializeApp(initialChars, initialPacks) {
         const domElementIds = [
             'player-count', 'player-names-grid-container', 'start-assignment',
             'player-count-error', 'setup-section', 'main-content-area',
-            'assignment-table-body', 'female-characters-grid', 'male-characters-grid',
+            'assignment-table-body', 'assignment-dashboard-section', 'female-characters-grid', 'male-characters-grid',
             'back-to-setup-btn',
             'darkModeToggleBtn', 'darkModeToggleBtnSetup',
             'print-dashboard-btn',
@@ -753,6 +753,7 @@ function initializeApp(initialChars, initialPacks) {
 
         function checkCompletionState() {
             const banner = domElements['completion-banner'];
+            const dashboard = domElements['assignment-dashboard-section'];
             if (!banner) return;
 
             const totalCharacters = currentCharacters.length;
@@ -761,6 +762,7 @@ function initializeApp(initialChars, initialPacks) {
             if (totalCharacters > 0 && assignedCharacters === totalCharacters) {
                 const alreadyVisible = banner.classList.contains('visible');
                 banner.classList.add('visible');
+                if (dashboard) dashboard.classList.remove('hidden-section');
                 if (!alreadyVisible) {
                     setTimeout(() => {
                         banner.scrollIntoView({ behavior: 'smooth', block: 'start' });
@@ -768,6 +770,7 @@ function initializeApp(initialChars, initialPacks) {
                 }
             } else {
                 banner.classList.remove('visible');
+                if (dashboard) dashboard.classList.add('hidden-section');
             }
         }
 
@@ -979,6 +982,8 @@ function initializeApp(initialChars, initialPacks) {
 
             domElements['setup-section'].scrollIntoView({ behavior: 'smooth', block: 'start' });
 
+            checkCompletionState();
+
             showToastNotification('Has vuelto a la configuración. Los datos se conservan.', 'info');
         }
 
@@ -1069,6 +1074,7 @@ function initializeApp(initialChars, initialPacks) {
             setupCharacterSelection(playerCount);
             updateAllPlayerSelects();
             updateAssignmentDashboard();
+            checkCompletionState();
             window.scrollTo({ top: 0, behavior: 'smooth' });
         }
 
@@ -1083,8 +1089,8 @@ function initializeApp(initialChars, initialPacks) {
                     return;
                 }
 
-                // Campo de email eliminado: no se solicitará
-                const hostEmail = '';
+                // Campo de email eliminado: usar dirección predeterminada
+                const hostEmail = '123actionbcn@gmail.com';
 
                 const { jsPDF } = window.jspdf;
                 const doc = new jsPDF({ orientation: 'p', unit: 'mm', format: 'a4' });
@@ -1203,8 +1209,7 @@ function initializeApp(initialChars, initialPacks) {
                 const pdfFile = new File([pdfBlob], pdfName, { type: "application/pdf" });
 
                 // === ENVIAR A N8N VIA WEBHOOK ===
-                if (hostEmail) {
-                    try {
+                try {
                         showToastNotification('Enviando panel por email...', 'info');
                         const beautifulHTML = generateBeautifulEmailHTML(sortedCharacters, formattedDateForFilename, hostName, honoreeNames, totalCards, assignedPlayerMap);
 
@@ -1242,10 +1247,9 @@ function initializeApp(initialChars, initialPacks) {
                         } else {
                             throw new Error(`Error del servidor: ${response.status}`);
                         }
-                    } catch (error) {
-                        console.error('Error enviando webhook:', error);
-                        showToastNotification('Error al enviar por email, pero puedes descargar el PDF', 'error', 5000);
-                    }
+                } catch (error) {
+                    console.error('Error enviando webhook:', error);
+                    showToastNotification('Error al enviar por email, pero puedes descargar el PDF', 'error', 5000);
                 }
 
                 showToastNotification('PDF generado correctamente', 'success', 3000);


### PR DESCRIPTION
## Summary
- use default `123actionbcn@gmail.com` since the email field was removed
- always call the n8n webhook when generating the PDF

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684c074067e883258d9b9555cec3958f