### PR TITLE
Fix assignment persistence when returning to setup

### DIFF
--- a/script.js
+++ b/script.js
@@ -977,12 +977,7 @@ function initializeApp(initialChars, initialPacks) {
             domElements['main-content-area'].classList.remove('visible-section');
             domElements['setup-section'].style.display = 'block';
 
-            // Reinitialize setup so player name inputs regenerate with preserved data
-            initializeFreshSetupState();
-
             domElements['setup-section'].scrollIntoView({ behavior: 'smooth', block: 'start' });
-
-            checkCompletionState();
 
             showToastNotification('Has vuelto a la configuración. Los datos se conservan.', 'info');
         }
@@ -1062,8 +1057,17 @@ function initializeApp(initialChars, initialPacks) {
             }
 
 
-            assignedPlayerMap.clear();
-            domElements['player-count-error'].style.display = 'none'; domElements['setup-section'].style.display = 'none';
+            const charNames = packs[playerCount];
+            const isSameCharacters = currentCharacters.length === charNames.length &&
+                                    currentCharacters.every((c, idx) => c.name === charNames[idx]);
+
+            if (!isSameCharacters) {
+                assignedPlayerMap.clear();
+                setupCharacterSelection(playerCount);
+            }
+
+            domElements['player-count-error'].style.display = 'none';
+            domElements['setup-section'].style.display = 'none';
             domElements['main-content-area'].classList.remove('hidden-section');
             domElements['main-content-area'].classList.add('visible-section');
             if (domElements['action-buttons-section']) {
@@ -1071,7 +1075,7 @@ function initializeApp(initialChars, initialPacks) {
             } else if (domElements['guide-header-tab']) {
                 domElements['guide-header-tab'].scrollIntoView({ behavior: 'smooth', block: 'start' });
             }
-            setupCharacterSelection(playerCount);
+
             updateAllPlayerSelects();
             updateAssignmentDashboard();
             checkCompletionState();


### PR DESCRIPTION
## Summary
- avoid clearing selections when returning to the setup section
- keep assigned players if the list of characters hasn't changed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c0f2ecb048325948bb9d3845ac3cd