### PR TITLE
Fix share menu button alignment

### DIFF
--- a/script.js
+++ b/script.js
@@ -1773,11 +1773,19 @@ function openShareMenu(trigger) {
     const menu = document.createElement('div');
     menu.className = 'share-menu';
     menu.innerHTML = `
-        <a href="https://wa.me/?text=${encodeURIComponent(txt)}" target="_blank"><i class="fab fa-whatsapp share-menu-icon"></i>WhatsApp</a>
-        <button type="button" class="share-copy-option"><i class="fas fa-copy share-menu-icon"></i>Copiar texto</button>
-        <a href="mailto:?subject=${encodeURIComponent('Tu personaje: ' + charName)}&body=${encodeURIComponent(txt)}"><i class="fas fa-envelope share-menu-icon"></i>Email</a>
+        <a href="https://wa.me/?text=${encodeURIComponent(txt)}" target="_blank">
+            <div class="share-option"><i class="fab fa-whatsapp share-menu-icon"></i><span>WhatsApp</span></div>
+        </a>
+        <button type="button" class="share-copy-option">
+            <div class="share-option"><i class="fas fa-copy share-menu-icon"></i><span>Copiar texto</span></div>
+        </button>
+        <a href="mailto:?subject=${encodeURIComponent('Tu personaje: ' + charName)}&body=${encodeURIComponent(txt)}">
+            <div class="share-option"><i class="fas fa-envelope share-menu-icon"></i><span>Email</span></div>
+        </a>
         <div style="border-top: 1px solid #c0a062; margin: 4px 0;"></div>
-        <button type="button" class="share-print-option"><i class="fas fa-print share-menu-icon"></i>Imprimir Invitación</button>
+        <button type="button" class="share-print-option">
+            <div class="share-option"><i class="fas fa-print share-menu-icon"></i><span>Imprimir Invitación</span></div>
+        </button>
     `;
     
     document.body.appendChild(menu);

--- a/style.css
+++ b/style.css
@@ -1151,7 +1151,7 @@ button .fas, button .fab { margin-right: 8px; }
     box-sizing: border-box;
     display: flex;
     align-items: center;
-    gap: 12px;
+    gap: 8px;
     width: 100%;
     padding: 12px 18px;
     background: none;
@@ -1184,7 +1184,7 @@ button .fas, button .fab { margin-right: 8px; }
 
 .share-menu-icon {
     color: #e3c896;
-    width: 20px;
+    width: 1em;
     text-align: center;
     font-size: 1.1em;
 }

--- a/style.css
+++ b/style.css
@@ -1147,16 +1147,14 @@ button .fas, button .fab { margin-right: 8px; }
     min-width: 220px;
 }
 
-.share-menu a, .share-menu button {
+.share-menu a,
+.share-menu button {
     box-sizing: border-box;
-    display: flex;
-    align-items: center;
-    gap: 8px;
     width: 100%;
-    padding: 12px 18px;
+    padding: 0;
+    margin: 0;
     background: none;
     border: none;
-    margin: 0;
     box-shadow: none;
     text-align: left;
     text-decoration: none;
@@ -1168,15 +1166,21 @@ button .fas, button .fab { margin-right: 8px; }
     font-weight: 600;
 }
 
-.share-menu a:hover, .share-menu button:hover {
+.share-option {
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 18px;
+    width: 100%;
+}
+
+.share-menu a:hover .share-option,
+.share-menu button:hover .share-option {
     background: rgba(255,255,255,0.1);
 }
 
-.share-menu button:hover {
-    transform: none;
-    box-shadow: none;
-}
-
+.share-menu button:hover,
 .share-menu button:active {
     transform: none;
     box-shadow: none;

--- a/style.css
+++ b/style.css
@@ -1121,7 +1121,12 @@ button .fas, button .fab { margin-right: 8px; }
     align-items: center;
     justify-content: center;
     gap: 8px;
-    transition: all 0.2s ease;
+    text-shadow: none !important;
+    box-shadow: 2px 2px 5px rgba(0,0,0,0.3), inset 1px 1px 3px rgba(0,0,0,0.2);
+    transform: rotate(1deg);
+    text-transform: none;
+    letter-spacing: normal;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
     font-size: 1.1em !important;
     width: 100%;
 }

--- a/style.css
+++ b/style.css
@@ -1143,7 +1143,7 @@ button .fas, button .fab { margin-right: 8px; }
 }
 
 .share-menu a, .share-menu button {
-    box-sizing: border-box; 
+    box-sizing: border-box;
     display: flex;
     align-items: center;
     gap: 12px;
@@ -1151,6 +1151,8 @@ button .fas, button .fab { margin-right: 8px; }
     padding: 12px 18px;
     background: none;
     border: none;
+    margin: 0;
+    box-shadow: none;
     text-align: left;
     text-decoration: none;
     color: #f2dfb3;
@@ -1163,6 +1165,16 @@ button .fas, button .fab { margin-right: 8px; }
 
 .share-menu a:hover, .share-menu button:hover {
     background: rgba(255,255,255,0.1);
+}
+
+.share-menu button:hover {
+    transform: none;
+    box-shadow: none;
+}
+
+.share-menu button:active {
+    transform: none;
+    box-shadow: none;
 }
 
 .share-menu-icon {


### PR DESCRIPTION
## Summary
- normalize share menu buttons and links to remove default button spacing and shadow
- prevent share menu buttons from scaling on hover/active states

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b1dc651fc83258f35c32450753f4f